### PR TITLE
Add links to developers page

### DIFF
--- a/cookbooks/financial-agent-demo/.env.example
+++ b/cookbooks/financial-agent-demo/.env.example
@@ -1,5 +1,5 @@
 # Required: Bigdata.com API credentials
-# Sign up at https://bigdata.com to get these credentials
+# Request access at https://bigdata.com/for-developers to get these credentials
 BIGDATA_USERNAME=your_username_here
 BIGDATA_PASSWORD=your_password_here
 

--- a/cookbooks/financial-agent-demo/README.md
+++ b/cookbooks/financial-agent-demo/README.md
@@ -81,6 +81,9 @@ BIGDATA_PASSWORD=your_password_here
 GOOGLE_API_KEY=your_google_api_key_here
 ```
 
+> [!IMPORTANT]
+> Visit [our website](https://www.bigdata.com/for-developers?utm_source=github) to request access to your Bigdata API credentials.
+
 ### 3. Run Interactive Demo
 
 ```bash


### PR DESCRIPTION
Adding correct links to the page on the Bigdata.com website where users can request their API credentials.